### PR TITLE
fix: fix auto discover events in Laravel 11

### DIFF
--- a/src/FilamentLoggerEventServiceProvider.php
+++ b/src/FilamentLoggerEventServiceProvider.php
@@ -28,4 +28,14 @@ class FilamentLoggerEventServiceProvider extends ServiceProvider
         );
         return $listen;
     }
+
+    /**
+     * Determine if events and listeners should be automatically discovered.
+     *
+     * @return bool
+     */
+    public function shouldDiscoverEvents()
+    {
+        return get_class($this) === __CLASS__ && static::$shouldDiscoverEvents === true;
+    }
 }


### PR DESCRIPTION
This PR aims to override the original ```shouldDiscoverEvents``` method in ```FilamentLoggerServiceProvider``` to return the correct value, since ```get_class($this) === __CLASS__⁠``` always returns false when ```$this``` is an extension of ```__CLASS__```